### PR TITLE
Add context to error message

### DIFF
--- a/src/ErrorGenerator/CustomErrorGenerator.test.ts
+++ b/src/ErrorGenerator/CustomErrorGenerator.test.ts
@@ -34,6 +34,19 @@ describe("CustomErrorGenerator.ts", () => {
 				errorType: "CustomErrorGenerator"
 			});
 		});
+		it("should return the correct error object with context", () => {
+			const customErrorGenerator = new CustomErrorGenerator(
+				"CustomErrorGenerator",
+				errors
+			);
+			expect(customErrorGenerator.newError("ERROR_1", "context")).toEqual(
+				{
+					message: "Error 1",
+					errorType: "CustomErrorGenerator",
+					context: "context"
+				}
+			);
+		});
 	});
 	describe("getIsOkFunction", () => {
 		it("should return a function", () => {

--- a/src/ErrorGenerator/CustomErrorGenerator.ts
+++ b/src/ErrorGenerator/CustomErrorGenerator.ts
@@ -5,6 +5,7 @@ export type ErrorMessages = {
 export interface CustomErrorObject<T> {
 	message: T[keyof T];
 	errorType: string;
+	context?: string;
 }
 
 export class CustomErrorGenerator<T extends ErrorMessages> {
@@ -15,10 +16,11 @@ export class CustomErrorGenerator<T extends ErrorMessages> {
 		this.errorMessages = errorMessages;
 	}
 
-	newError(errorKey: keyof T): CustomErrorObject<T> {
+	newError(errorKey: keyof T, context?: string): CustomErrorObject<T> {
 		return {
 			message: this.errorMessages[errorKey],
-			errorType: this.name
+			errorType: this.name,
+			context: context
 		};
 	}
 }


### PR DESCRIPTION
Add context field to error message so it is easy to understand what entities the error message is related to.